### PR TITLE
Removing the master and slave vocabulary

### DIFF
--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/rdataset.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/rdataset.py
@@ -169,7 +169,7 @@ class Rdataset(dns.set.Set):
 
     def to_text(self, name=None, origin=None, relativize=True,
                 override_rdclass=None, **kw):
-        """Convert the rdataset into DNS master file format.
+        """Convert the rdataset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/rdtypes/ANY/SOA.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/rdtypes/ANY/SOA.py
@@ -22,7 +22,7 @@ import dns.name
 class SOA(dns.rdata.Rdata):
     """SOA record
 
-    @ivar mname: the SOA MNAME (master name) field
+    @ivar mname: the SOA MNAME (main name) field
     @type mname: dns.name.Name object
     @ivar rname: the SOA RNAME (responsible name) field
     @type rname: dns.name.Name object

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/rrset.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/rrset.py
@@ -84,7 +84,7 @@ class RRset(dns.rdataset.Rdataset):
         return True
 
     def to_text(self, origin=None, relativize=True, **kw):
-        """Convert the RRset into DNS master file format.
+        """Convert the RRset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/tokenizer.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/tokenizer.py
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Tokenize DNS master file format"""
+"""Tokenize DNS main file format"""
 
 import cStringIO
 import sys
@@ -47,7 +47,7 @@ class UngetBufferFull(dns.exception.DNSException):
     pass
 
 class Token(object):
-    """A DNS master file format token.
+    """A DNS main file format token.
 
     @ivar ttype: The token type
     @type ttype: int
@@ -156,7 +156,7 @@ class Token(object):
             raise IndexError
 
 class Tokenizer(object):
-    """A DNS master file format tokenizer.
+    """A DNS main file format tokenizer.
 
     A token is a (type, value) tuple, where I{type} is an int, and
     I{value} is a string.  The valid types are EOF, EOL, WHITESPACE,

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/zone.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/dns/zone.py
@@ -520,8 +520,8 @@ class Zone(object):
             raise NoNS
 
 
-class _MasterReader(object):
-    """Read a DNS master file
+class _MainReader(object):
+    """Read a DNS main file
 
     @ivar tok: The tokenizer
     @type tok: dns.tokenizer.Tokenizer object
@@ -569,7 +569,7 @@ class _MasterReader(object):
                 break
 
     def _rr_line(self):
-        """Process one line from a DNS master file."""
+        """Process one line from a DNS main file."""
         # Name
         if self.current_origin is None:
             raise UnknownOrigin
@@ -642,7 +642,7 @@ class _MasterReader(object):
         rds.add(rd, ttl)
 
     def read(self):
-        """Read a DNS master file and build a zone object.
+        """Read a DNS main file and build a zone object.
 
         @raises dns.zone.NoSOA: No SOA RR was found at the zone origin
         @raises dns.zone.NoNS: No NS RRset was found at the zone origin
@@ -704,7 +704,7 @@ class _MasterReader(object):
                                                            filename)
                         self.current_origin = new_origin
                     else:
-                        raise dns.exception.SyntaxError("Unknown master file directive '" + u + "'")
+                        raise dns.exception.SyntaxError("Unknown main file directive '" + u + "'")
                     continue
                 self.tok.unget(token)
                 self._rr_line()
@@ -721,12 +721,12 @@ class _MasterReader(object):
 def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=False, check_origin=True):
-    """Build a zone object from a master file format string.
+    """Build a zone object from a main file format string.
 
-    @param text: the master file format input
+    @param text: the main file format input
     @type text: string.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.
@@ -755,7 +755,7 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
     if filename is None:
         filename = '<string>'
     tok = dns.tokenizer.Tokenizer(text, filename)
-    reader = _MasterReader(tok, origin, rdclass, relativize, zone_factory,
+    reader = _MainReader(tok, origin, rdclass, relativize, zone_factory,
                            allow_include=allow_include,
                            check_origin=check_origin)
     reader.read()
@@ -764,12 +764,12 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
 def from_file(f, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=True, check_origin=True):
-    """Read a master file and build a zone object.
+    """Read a main file and build a zone object.
 
     @param f: file or string.  If I{f} is a string, it is treated
     as the name of a file to open.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/apitools/base/py/batch.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/apitools/base/py/batch.py
@@ -148,7 +148,7 @@ class BatchApiRequest(object):
         method_config, request, global_params=global_params,
         upload_config=upload_config)
 
-    # Create the request and add it to our master list.
+    # Create the request and add it to our main list.
     api_request = self.ApiCall(
         http_request, self.retryable_codes, service, method_config)
     self.api_requests.append(api_request)

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1/container_v1_client.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1/container_v1_client.py
@@ -113,7 +113,7 @@ class ContainerV1(base_api.BaseApiClient):
 
     def Create(self, request, global_params=None):
       """Creates a cluster, consisting of the specified number and type of Google.
-Compute Engine instances, plus a Kubernetes master endpoint.
+Compute Engine instances, plus a Kubernetes main endpoint.
 
 By default, the cluster is created in the project's
 [default network]('/compute/docs/networking#networks_1').

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1/container_v1_messages.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1/container_v1_messages.py
@@ -29,20 +29,20 @@ class Cluster(_messages.Message):
     createTime: [Output only] The time the cluster was created, in
       [RFC3339](href='https://www.ietf.org/rfc/rfc3339.txt) text format.
       @OutputOnly.
-    currentMasterVersion: [Output only] The current software version of the
-      master endpoint. @OutputOnly.
+    currentMainVersion: [Output only] The current software version of the
+      main endpoint. @OutputOnly.
     currentNodeVersion: [Output only] The current version of the node software
       components. If they are currently at different versions because they're
       in the process of being upgraded, this reflects the minimum version of
       any of them. @OutputOnly.
     description: An optional description of this cluster.
-    endpoint: [Output only] The IP address of this cluster's Kubernetes master
+    endpoint: [Output only] The IP address of this cluster's Kubernetes main
       endpoint. The endpoint can be accessed from the internet at
       `https://username:password@endpoint/`. @OutputOnly.  See the
-      `masterAuth` property of this resource for username and password
+      `mainAuth` property of this resource for username and password
       information.
     initialClusterVersion: [Output only] The software version of Kubernetes
-      master and kubelets used in the cluster when it was first created. The
+      main and kubelets used in the cluster when it was first created. The
       version can be upgraded over time. @OutputOnly.
     initialNodeCount: The number of nodes to create in this cluster. You must
       ensure that your Compute Engine [resource quota](/compute/docs/resource-
@@ -55,7 +55,7 @@ class Cluster(_messages.Message):
       Currently available options:  * "logging.googleapis.com" - the Google
       Cloud Logging service * "none" - no logs will be exported from the
       cluster * "" - default value; the default is "logging.googleapis.com"
-    masterAuth: The authentication information for accessing the master.
+    mainAuth: The authentication information for accessing the main.
     monitoringService: The monitoring service that the cluster should write
       metrics to. Currently available options:  * "monitoring.googleapis.com"
       - the Google Cloud Monitoring service * "none" - no metrics will be
@@ -97,7 +97,7 @@ class Cluster(_messages.Message):
       RUNNING: The RUNNING state indicates the cluster has been created and is
         fully usable.
       RECONCILING: The RECONCILING state indicates that some work is actively
-        being done on the cluster, such as upgrading the master or node
+        being done on the cluster, such as upgrading the main or node
         software. Details can be found in the statusMessage field.
       STOPPING: The STOPPING state indicates the cluster is being deleted.
       ERROR: The ERROR state indicates the cluster may be unusable. Details
@@ -112,7 +112,7 @@ class Cluster(_messages.Message):
 
   clusterIpv4Cidr = _messages.StringField(1)
   createTime = _messages.StringField(2)
-  currentMasterVersion = _messages.StringField(3)
+  currentMainVersion = _messages.StringField(3)
   currentNodeVersion = _messages.StringField(4)
   description = _messages.StringField(5)
   endpoint = _messages.StringField(6)
@@ -120,7 +120,7 @@ class Cluster(_messages.Message):
   initialNodeCount = _messages.IntegerField(8, variant=_messages.Variant.INT32)
   instanceGroupUrls = _messages.StringField(9, repeated=True)
   loggingService = _messages.StringField(10)
-  masterAuth = _messages.MessageField('MasterAuth', 11)
+  mainAuth = _messages.MessageField('MainAuth', 11)
   monitoringService = _messages.StringField(12)
   name = _messages.StringField(13)
   network = _messages.StringField(14)
@@ -137,7 +137,7 @@ class ClusterUpdate(_messages.Message):
   """ClusterUpdate describes an update to the cluster.
 
   Fields:
-    desiredMasterVersion: The Kubernetes version to change the master to
+    desiredMainVersion: The Kubernetes version to change the main to
       (typically an upgrade). Use "-" to upgrade to the latest version
       supported by the server.
     desiredNodeVersion: The Kubernetes version to change the nodes to
@@ -145,7 +145,7 @@ class ClusterUpdate(_messages.Message):
       supported by the server.
   """
 
-  desiredMasterVersion = _messages.StringField(1)
+  desiredMainVersion = _messages.StringField(1)
   desiredNodeVersion = _messages.StringField(2)
 
 
@@ -302,8 +302,8 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master endpoint.
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main endpoint.
   Authentication can be done using HTTP basic auth or using client
   certificates.
 
@@ -315,10 +315,10 @@ class MasterAuth(_messages.Message):
     clusterCaCertificate: [Output only] Base64 encoded public certificate that
       is the root of trust for the cluster. @OutputOnly.
     password: The password to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint. Because the master endpoint is open to
+      the Kubernetes main endpoint. Because the main endpoint is open to
       the internet, you should create a strong password.
     username: The username to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint.
+      the Kubernetes main endpoint.
   """
 
   clientCertificate = _messages.StringField(1)
@@ -377,7 +377,7 @@ class Operation(_messages.Message):
       TYPE_UNSPECIFIED: Not set.
       CREATE_CLUSTER: Cluster create.
       DELETE_CLUSTER: Cluster delete.
-      UPGRADE_MASTER: A master upgrade.
+      UPGRADE_MASTER: A main upgrade.
       UPGRADE_NODES: A node upgrade.
       REPAIR_CLUSTER: Cluster repair.
     """

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
@@ -178,11 +178,11 @@ class ContainerV1beta1(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes master instance.
+      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes main instance.
 
 The cluster is created in the project's default network.
 
-A firewall is added that allows traffic into port 443 on the master, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
+A firewall is added that allows traffic into port 443 on the main, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
 
 Finally, an entry is added to the project's global metadata indicating which CIDR range is being used by the cluster.
 
@@ -197,7 +197,7 @@ Finally, an entry is added to the project's global metadata indicating which CID
           config, request, global_params=global_params)
 
     def Delete(self, request, global_params=None):
-      """Deletes the cluster, including the Kubernetes master and all worker nodes.
+      """Deletes the cluster, including the Kubernetes main and all worker nodes.
 
 Firewalls and routes that were configured at cluster creation are also deleted.
 

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
@@ -18,7 +18,7 @@ class Cluster(_messages.Message):
     StatusValueValuesEnum: [Output only] The current status of this cluster.
 
   Fields:
-    clusterApiVersion: The API version of the Kubernetes master and kubelets
+    clusterApiVersion: The API version of the Kubernetes main and kubelets
       running in this cluster. Leave blank to pick up the latest stable
       release, or specify a version of the form "x.y.z". The Google Container
       Engine release notes lists the currently supported versions. If an
@@ -38,12 +38,12 @@ class Cluster(_messages.Message):
     enableCloudMonitoring: Whether metrics from the cluster should be made
       available via the Google Cloud Monitoring service.
     endpoint: [Output only] The IP address of this cluster's Kubernetes
-      master. The endpoint can be accessed from the internet at
-      https://username:password@endpoint/.  See the masterAuth property of
+      main. The endpoint can be accessed from the internet at
+      https://username:password@endpoint/.  See the mainAuth property of
       this resource for username and password information.
     instanceGroupUrls: [Output only] The resource URLs of [instance
       groups](/compute/docs/instance-groups/) associated with this cluster.
-    masterAuth: The authentication information for accessing the master.
+    mainAuth: The authentication information for accessing the main.
     name: The name of this cluster. The name must be unique within this
       project and zone, and can be up to 40 characters with the following
       restrictions:   - Lowercase letters, numbers, and hyphens only. - Must
@@ -56,7 +56,7 @@ class Cluster(_messages.Message):
       node for hosting containers.
     numNodes: The number of nodes to create in this cluster. You must ensure
       that your Compute Engine resource quota is sufficient for this number of
-      instances plus one (to include the master). You must also have available
+      instances plus one (to include the main). You must also have available
       firewall and routes quota.
     selfLink: [Output only] Server-defined URL for the resource.
     servicesIpv4Cidr: [Output only] The IP address range of the Kubernetes
@@ -91,7 +91,7 @@ class Cluster(_messages.Message):
   enableCloudMonitoring = _messages.BooleanField(6)
   endpoint = _messages.StringField(7)
   instanceGroupUrls = _messages.StringField(8, repeated=True)
-  masterAuth = _messages.MessageField('MasterAuth', 9)
+  mainAuth = _messages.MessageField('MainAuth', 9)
   name = _messages.StringField(10)
   network = _messages.StringField(11)
   nodeConfig = _messages.MessageField('NodeConfig', 12)
@@ -262,14 +262,14 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master. Authentication
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main. Authentication
   is either done using HTTP basic authentication or using a bearer token.
 
   Fields:
-    bearerToken: The token used to authenticate API requests to the master.
+    bearerToken: The token used to authenticate API requests to the main.
       The token is to be included in an HTTP Authorization Header in all
-      requests to the master endpoint. The format of the header is:
+      requests to the main endpoint. The format of the header is:
       "Authorization: Bearer ".
     clientCertificate: [Output only] Base64 encoded public certificate used by
       clients to authenticate to the cluster endpoint.
@@ -278,10 +278,10 @@ class MasterAuth(_messages.Message):
     clusterCaCertificate: [Output only] Base64 encoded public certificate that
       is the root of trust for the cluster.
     password: The password to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint. Because the master endpoint is open to
+      the Kubernetes main endpoint. Because the main endpoint is open to
       the internet, you should create a strong password.
     user: The username to use for HTTP basic authentication when accessing the
-      Kubernetes master endpoint.
+      Kubernetes main endpoint.
   """
 
   bearerToken = _messages.StringField(1)

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta2/container_v1beta2_client.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta2/container_v1beta2_client.py
@@ -190,7 +190,7 @@ class ContainerV1beta2(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes master endpoint.
+      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes main endpoint.
 
 By default, the cluster is created in the project's default network.
 

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta2/container_v1beta2_messages.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta2/container_v1beta2_messages.py
@@ -24,8 +24,8 @@ class Cluster(_messages.Message):
       172.16.0.0/12.
     creationTimestamp: [Output only] The time the cluster was created, in
       RFC3339 text format.
-    currentMasterVersion: [Output only] The current software version of the
-      master endpoint.
+    currentMainVersion: [Output only] The current software version of the
+      main endpoint.
     currentNodeVersion: [Output only] The current version of the node software
       components. If they are currently at different versions because they're
       in the process of being upgraded, this reflects the minimum version of
@@ -37,14 +37,14 @@ class Cluster(_messages.Message):
       components themselves.
     enableCloudMonitoring: Whether metrics from the cluster should be made
       available via the Google Cloud Monitoring service.
-    endpoint: [Output only] The IP address of this cluster's Kubernetes master
+    endpoint: [Output only] The IP address of this cluster's Kubernetes main
       endpoint. The endpoint can be accessed from the internet at
-      https://username:password@endpoint/.  See the masterAuth property of
+      https://username:password@endpoint/.  See the mainAuth property of
       this resource for username and password information.
     initialClusterVersion: [Output only] The software version of Kubernetes
-      master and kubelets used in the cluster when it was first created. The
+      main and kubelets used in the cluster when it was first created. The
       version can be upgraded over time.
-    masterAuth: The authentication information for accessing the master.
+    mainAuth: The authentication information for accessing the main.
     name: The name of this cluster. The name must be unique within this
       project and zone, and can be up to 40 characters with the following
       restrictions:   - Lowercase letters, numbers, and hyphens only. - Must
@@ -88,14 +88,14 @@ class Cluster(_messages.Message):
 
   containerIpv4Cidr = _messages.StringField(1)
   creationTimestamp = _messages.StringField(2)
-  currentMasterVersion = _messages.StringField(3)
+  currentMainVersion = _messages.StringField(3)
   currentNodeVersion = _messages.StringField(4)
   description = _messages.StringField(5)
   enableCloudLogging = _messages.BooleanField(6)
   enableCloudMonitoring = _messages.BooleanField(7)
   endpoint = _messages.StringField(8)
   initialClusterVersion = _messages.StringField(9)
-  masterAuth = _messages.MessageField('MasterAuth', 10)
+  mainAuth = _messages.MessageField('MainAuth', 10)
   name = _messages.StringField(11)
   network = _messages.StringField(12)
   nodeConfig = _messages.MessageField('NodeConfig', 13)
@@ -112,13 +112,13 @@ class ClusterUpdate(_messages.Message):
   """A ClusterUpdate object.
 
   Fields:
-    desiredMasterVersion: The Kubernetes version to change the master to
+    desiredMainVersion: The Kubernetes version to change the main to
       (typically an upgrade).
     desiredNodeVersion: The Kubernetes version to change the nodes to
       (typically an upgrade).
   """
 
-  desiredMasterVersion = _messages.MessageField('ClusterVersion', 1)
+  desiredMainVersion = _messages.MessageField('ClusterVersion', 1)
   desiredNodeVersion = _messages.MessageField('ClusterVersion', 2)
 
 
@@ -308,16 +308,16 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master endpoint.
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main endpoint.
   Authentication is done using HTTP basic authentication.
 
   Fields:
     password: The password to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint. Because the master endpoint is open to
+      the Kubernetes main endpoint. Because the main endpoint is open to
       the internet, you should create a strong password.
     user: The username to use for HTTP basic authentication when accessing the
-      Kubernetes master endpoint.
+      Kubernetes main endpoint.
   """
 
   password = _messages.StringField(1)
@@ -371,12 +371,12 @@ class Operation(_messages.Message):
     Values:
       createCluster: <no description>
       deleteCluster: <no description>
-      upgradeMaster: <no description>
+      upgradeMain: <no description>
       upgradeNodes: <no description>
     """
     createCluster = 0
     deleteCluster = 1
-    upgradeMaster = 2
+    upgradeMain = 2
     upgradeNodes = 3
 
   class StatusValueValuesEnum(_messages.Enum):

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
@@ -150,7 +150,7 @@ class DatabaseInstance(_messages.Message):
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     project: The project ID of the project containing the Cloud SQL instance.
@@ -179,7 +179,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 6, repeated=True)
   ipv6Address = _messages.StringField(7)
   kind = _messages.StringField(8, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(9)
+  mainInstanceName = _messages.StringField(9)
   maxDiskSize = _messages.IntegerField(10)
   project = _messages.StringField(11)
   region = _messages.StringField(12)

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudapis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
@@ -187,13 +187,13 @@ class DatabaseInstance(_messages.Message):
     etag: HTTP 1.1 Entity tag for the resource.
     instanceType: The instance type. This can be one of the following.
       CLOUD_SQL_INSTANCE: A Cloud SQL instance that is not replicating from a
-      master. ON_PREMISES_INSTANCE: An instance running on the customer's
+      main. ON_PREMISES_INSTANCE: An instance running on the customer's
       premises. READ_REPLICA_INSTANCE: A Cloud SQL instance configured as a
       read-replica.
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     name: Name of the Cloud SQL instance. This does not include the project
@@ -205,7 +205,7 @@ class DatabaseInstance(_messages.Message):
       west1. Defaults to us-central. The region can not be changed after
       instance creation.
     replicaConfiguration: Configuration specific to read-replicas replicating
-      from on-premises masters.
+      from on-premises mains.
     replicaNames: The replicas of the instance.
     selfLink: The URI of this resource.
     serverCaCert: SSL configuration.
@@ -228,7 +228,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 5, repeated=True)
   ipv6Address = _messages.StringField(6)
   kind = _messages.StringField(7, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(8)
+  mainInstanceName = _messages.StringField(8)
   maxDiskSize = _messages.IntegerField(9)
   name = _messages.StringField(10)
   onPremisesConfiguration = _messages.MessageField('OnPremisesConfiguration', 11)
@@ -497,24 +497,24 @@ class MySqlReplicaConfiguration(_messages.Message):
 
   Fields:
     caCertificate: PEM representation of the trusted CA's x509 certificate.
-    clientCertificate: PEM representation of the slave's x509 certificate.
-    clientKey: PEM representation of the slave's private key. The
+    clientCertificate: PEM representation of the subordinate's x509 certificate.
+    clientKey: PEM representation of the subordinate's private key. The
       corresponsing public key is encoded in the client's certificate.
     connectRetryInterval: Seconds to wait between connect retries. MySQL's
       default is 60 seconds.
     dumpFilePath: Path to a SQL dump file in Google Cloud Storage from which
-      the slave instance is to be created. The URI is in the form
+      the subordinate instance is to be created. The URI is in the form
       gs://bucketName/fileName. Compressed gzip files (.gz) are also
       supported. Dumps should have the binlog co-ordinates from which
-      replication should begin. This can be accomplished by setting --master-
+      replication should begin. This can be accomplished by setting --main-
       data to 1 when using mysqldump.
     kind: This is always sql#mysqlReplicaConfiguration.
-    masterHeartbeatPeriod: Interval in milliseconds between replication
+    mainHeartbeatPeriod: Interval in milliseconds between replication
       heartbeats.
     password: The password for the replication connection.
     sslCipher: A list of permissible ciphers to use for SSL encryption.
     username: The username for the replication connection.
-    verifyServerCertificate: Whether or not to check the master's Common Name
+    verifyServerCertificate: Whether or not to check the main's Common Name
       value in the certificate that it sends during the SSL handshake.
   """
 
@@ -524,7 +524,7 @@ class MySqlReplicaConfiguration(_messages.Message):
   connectRetryInterval = _messages.IntegerField(4, variant=_messages.Variant.INT32)
   dumpFilePath = _messages.StringField(5)
   kind = _messages.StringField(6, default=u'sql#mysqlReplicaConfiguration')
-  masterHeartbeatPeriod = _messages.IntegerField(7)
+  mainHeartbeatPeriod = _messages.IntegerField(7)
   password = _messages.StringField(8)
   sslCipher = _messages.StringField(9)
   username = _messages.StringField(10)
@@ -638,16 +638,16 @@ class OperationsListResponse(_messages.Message):
 
 
 class ReplicaConfiguration(_messages.Message):
-  """Read-replica configuration for connecting to the master.
+  """Read-replica configuration for connecting to the main.
 
   Fields:
     kind: This is always sql#replicaConfiguration.
     mysqlReplicaConfiguration: MySQL specific configuration when replicating
-      from a MySQL on-premises master. Replication configuration information
+      from a MySQL on-premises main. Replication configuration information
       such as the username, password, certificates, and keys are not stored in
       the instance metadata. The configuration information is used only to set
       up the replication connection and is stored by MySQL in a file named
-      master.info in the data directory.
+      main.info in the data directory.
   """
 
   kind = _messages.StringField(1, default=u'sql#replicaConfiguration')

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/container/commands/clusters/upgrade.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/container/commands/clusters/upgrade.py
@@ -32,7 +32,7 @@ class UpgradeBeta(base.Command):
         help='The kubernetes release version to change the cluster to.'
         ' Omit to upgrade to the latest version offered by the server.')
     parser.add_argument(
-        '--master',
+        '--main',
         help=argparse.SUPPRESS,
         action='store_true')
     parser.add_argument(
@@ -64,8 +64,8 @@ class UpgradeBeta(base.Command):
 
     options = api_adapter.UpdateClusterOptions(
         version=args.cluster_version,
-        update_master=args.master,
-        update_nodes=(not args.master))
+        update_main=args.main,
+        update_nodes=(not args.main))
 
     try:
       op_ref = adapter.UpdateCluster(cluster_ref, options)

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/container/lib/api_adapter.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/container/lib/api_adapter.py
@@ -276,10 +276,10 @@ class UpdateClusterOptions(object):
 
   def __init__(self,
                version=None,
-               update_master=None,
+               update_main=None,
                update_nodes=None):
     self.version = version
-    self.update_master = bool(update_master)
+    self.update_main = bool(update_main)
     self.update_nodes = bool(update_nodes)
 
 
@@ -290,7 +290,7 @@ class V1Adapter(APIAdapter):
     return cluster_ref.zone
 
   def Version(self, cluster):
-    return cluster.currentMasterVersion
+    return cluster.currentMainVersion
 
   def PrintClusters(self, clusters):
     list_printer.PrintResourceList(
@@ -316,7 +316,7 @@ class V1Adapter(APIAdapter):
         name=cluster_ref.clusterId,
         initialNodeCount=options.num_nodes,
         nodeConfig=node_config,
-        masterAuth=self.messages.MasterAuth(username=options.user,
+        mainAuth=self.messages.MainAuth(username=options.user,
                                             password=options.password))
     if options.cluster_version:
       cluster.initialClusterVersion = options.cluster_version
@@ -345,9 +345,9 @@ class V1Adapter(APIAdapter):
     if options.update_nodes:
       update = self.messages.ClusterUpdate(
           desiredNodeVersion=options.version)
-    elif options.update_master:
+    elif options.update_main:
       update = self.messages.ClusterUpdate(
-          desiredMasterVersion=options.version)
+          desiredMainVersion=options.version)
 
     op = self.client.projects_zones_clusters.Update(
         self.messages.ContainerProjectsZonesClustersUpdateRequest(
@@ -423,7 +423,7 @@ class V1beta1Adapter(APIAdapter):
             name=cluster_ref.clusterId,
             numNodes=options.num_nodes,
             nodeConfig=node_config,
-            masterAuth=self.messages.MasterAuth(user=options.user,
+            mainAuth=self.messages.MainAuth(user=options.user,
                                                 password=options.password),
             enableCloudLogging=options.enable_cloud_logging))
     if options.cluster_version:

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/container/lib/util.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/container/lib/util.py
@@ -71,7 +71,7 @@ def IsVersionOlderThan(first, second):
   return dist_version.LooseVersion(first) < dist_version.LooseVersion(second)
 
 
-KMASTER_NAME_FORMAT = 'k8s-{cluster_name}-master'
+KMASTER_NAME_FORMAT = 'k8s-{cluster_name}-main'
 # These are determined by the version of kubernetes the cluster is running.
 # This needs kept up to date when validating new cluster api versions.
 KMASTER_LEGACY_CERT_DIRECTORY = '/usr/share/nginx'
@@ -84,14 +84,14 @@ KMASTER_CERT_FILES = [KMASTER_CLIENT_KEY, KMASTER_CLIENT_CERT,
                       KMASTER_CERT_AUTHORITY]
 
 
-def GetKmasterCertDirectory(version):
-  """Returns the directory on the Kubernetes master where SSL certs are stored.
+def GetKmainCertDirectory(version):
+  """Returns the directory on the Kubernetes main where SSL certs are stored.
 
   Args:
     version: str, Kubernetes version (e.g. "0.4.4" or "0.5.2").
 
   Returns:
-    str, the path to SSL certs on the Kubernetes master.
+    str, the path to SSL certs on the Kubernetes main.
   """
   if IsVersionOlderThan(version, '0.5'):
     return KMASTER_LEGACY_CERT_DIRECTORY
@@ -250,7 +250,7 @@ class ClusterConfig(object):
         'project_id': project_id,
         'server': 'https://' + cluster.endpoint,
     }
-    auth = cluster.masterAuth
+    auth = cluster.mainAuth
     version = cls._ClusterVersion(cluster)
     if auth.clientCertificate and auth.clientKey and auth.clusterCaCertificate:
       kwargs['ca_data'] = auth.clusterCaCertificate
@@ -385,7 +385,7 @@ class ClusterConfig(object):
   def _FetchCertFiles(cls, cluster, project_id, cli):
     """Call into gcloud.compute.copy_files to copy certs from cluster.
 
-    Copies cert files from Kubernetes master into local config directory
+    Copies cert files from Kubernetes main into local config directory
     for the provided cluster.
 
     Args:
@@ -398,7 +398,7 @@ class ClusterConfig(object):
     instance_name = KMASTER_NAME_FORMAT.format(cluster_name=cluster.name)
 
     version = cls._ClusterVersion(cluster)
-    cert_dir = GetKmasterCertDirectory(version)
+    cert_dir = GetKmainCertDirectory(version)
     paths = [os.path.join(cert_dir, cert_file) for
              cert_file in KMASTER_CERT_FILES]
     # Put all the paths together in the same CLI argument so that SCP copies all
@@ -411,14 +411,14 @@ class ClusterConfig(object):
     config_dir = cls.GetConfigDir(cluster.name, cluster.zone, project_id)
     file_utils.MakeDir(config_dir)
     log.out.Print('Using gcloud compute copy-files to fetch ssl certs from '
-                  'cluster master...')
+                  'cluster main...')
     try:
       cli.Execute(['compute', 'copy-files', '--zone=' + cluster.zone,
                    remote_file_paths, config_dir])
       return True
     except exceptions.ToolException as error:
       log.error(
-          'Fetching ssl certs from cluster master failed:\n\n%s\n\n'
+          'Fetching ssl certs from cluster main failed:\n\n%s\n\n'
           'You can still interact with the cluster, but you may see a warning '
           'that certificate checking is disabled.',
           error)

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/dns/lib/import_util.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/dns/lib/import_util.py
@@ -48,7 +48,7 @@ def _SOATranslation(rdata, origin):
 
   Returns:
     str, The translation of the given SOA rdata which includes all the required
-    SOA fields. Note that the master NS name is left in a substitutable form
+    SOA fields. Note that the main NS name is left in a substitutable form
     because it is always provided by Cloud DNS.
   """
   return ' '.join(
@@ -182,7 +182,7 @@ def RecordSetsFromZoneFile(zone_file, domain):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     zone file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   zone_contents = zone.from_file(zone_file, domain, check_origin=False)
@@ -204,7 +204,7 @@ def RecordSetsFromYamlFile(yaml_file):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     yaml file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   record_sets = {}
@@ -224,7 +224,7 @@ def RecordSetsFromYamlFile(yaml_file):
     record_set.rrdatas = yaml_record_set['rrdatas']
 
     if rdata_type is rdatatype.SOA:
-      # Make master NS name substitutable.
+      # Make main NS name substitutable.
       record_set.rrdatas[0] = re.sub(r'\S+', '{0}', record_set.rrdatas[0],
                                      count=1)
 
@@ -252,14 +252,14 @@ def _RecordSetCopy(record_set):
 
 
 def _SOAReplacement(current_record, record_to_be_imported):
-  """Returns the replacement SOA record with restored master NS name.
+  """Returns the replacement SOA record with restored main NS name.
 
   Args:
     current_record: ResourceRecordSet, Current record-set.
     record_to_be_imported: ResourceRecordSet, Record-set to be imported.
 
   Returns:
-    ResourceRecordSet, the replacement SOA record with restored master NS name.
+    ResourceRecordSet, the replacement SOA record with restored main NS name.
   """
   replacement = _RecordSetCopy(record_to_be_imported)
   replacement.rrdatas[0] = replacement.rrdatas[0].format(

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/gcloud/sdktools/root/init.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/gcloud/sdktools/root/init.py
@@ -45,7 +45,7 @@ class Init(base.Command):
           git repository associated with PROJECT. This repository will
           automatically be connected to Google, and it will use the credentials
           indicated as _active_ by `gcloud auth list`. Pushing
-          to the origin's _master_ branch will trigger an App Engine deployment
+          to the origin's _main_ branch will trigger an App Engine deployment
           using the contents of that branch.
 
           **Note: this command will be changing soon. Consider using
@@ -61,7 +61,7 @@ class Init(base.Command):
             $ cd MYPROJECT/default
             $ git pull
               https://github.com/GoogleCloudPlatform/appengine-helloworld-python
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/source/commands/clone.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/source/commands/clone.py
@@ -26,7 +26,7 @@ class Clone(base.Command):
           this `{command}` will clone the Google-hosted git repository
           associated with PROJECT. This repository will automatically be
           connected to Google, and it will use the credentials indicated as
-          _active_ by `gcloud auth list`. Pushing to the origin's _master_
+          _active_ by `gcloud auth list`. Pushing to the origin's _main_
           branch will trigger an App Engine deployment using the contents
           of that branch.
       """,
@@ -39,7 +39,7 @@ class Clone(base.Command):
             $ cd REPOSITORY_NAME
             $ git pull
               https://github.com/GoogleCloudPlatform/appengine-helloworld-python
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/sql/tools/instances/create.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/sql/tools/instances/create.py
@@ -98,11 +98,11 @@ class Create(base.Command):
         'instance',
         help='Cloud SQL instance ID.')
     parser.add_argument(
-        '--master-instance-name',
+        '--main-instance-name',
         required=False,
-        help='Name of the instance which will act as master in the replication '
+        help='Name of the instance which will act as main in the replication '
         'setup. The newly created instance will be a read replica of the '
-        'specified master instance.')
+        'specified main instance.')
     parser.add_argument(
         '--pricing-plan',
         '-p',
@@ -181,7 +181,7 @@ class Create(base.Command):
 
     instance_resource = util.ConstructInstanceFromArgs(sql_messages, args)
 
-    if args.master_instance_name:
+    if args.main_instance_name:
       replication = 'ASYNCHRONOUS'
       activation_policy = 'ALWAYS'
     else:

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/sql/util.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/sql/util.py
@@ -305,7 +305,7 @@ def ConstructInstanceFromArgs(sql_messages, args, original=None):
   instance_resource = sql_messages.DatabaseInstance(
       region=region,
       databaseVersion=database_version,
-      masterInstanceName=getattr(args, 'master_instance_name', None),
+      mainInstanceName=getattr(args, 'main_instance_name', None),
       settings=settings)
 
   return instance_resource

--- a/frontend/yes/google-cloud-sdk/.install/.backup/lib/jinja2/pkg_resources.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/lib/jinja2/pkg_resources.py
@@ -2693,7 +2693,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 
 try:

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/gslib/addlhelp/naming.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/gslib/commands/notification.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/gslib/commands/notification.py
@@ -126,7 +126,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://developers.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
@@ -159,7 +159,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/apitools/run_pylint.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/apitools/run_pylint.py
@@ -103,9 +103,9 @@ def get_files_for_linting(allow_limited=True):
     uses a specific commit or branch (a so-called diff base) to compare
     against for changed files. (This requires ``allow_limited=True``.)
 
-    To speed up linting on Travis pull requests against master, we manually
-    set the diff base to origin/master. We don't do this on non-pull requests
-    since origin/master will be equivalent to the currently checked out code.
+    To speed up linting on Travis pull requests against main, we manually
+    set the diff base to origin/main. We don't do this on non-pull requests
+    since origin/main will be equivalent to the currently checked out code.
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
@@ -122,11 +122,11 @@ def get_files_for_linting(allow_limited=True):
               linted.
     """
     diff_base = None
-    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+    if (os.getenv('TRAVIS_BRANCH') == 'main' and
             os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
-        # In the case of a pull request into master, we want to
-        # diff against HEAD in master.
-        diff_base = 'origin/master'
+        # In the case of a pull request into main, we want to
+        # diff against HEAD in main.
+        diff_base = 'origin/main'
     elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
         remote = os.getenv('GCLOUD_REMOTE_FOR_LINT')

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/emr/connection.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/emr/connection.py
@@ -398,8 +398,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -426,11 +426,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -461,7 +461,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -515,15 +515,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -710,15 +710,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/emr/step.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/kms/layer1.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds/__init__.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds/__init__.py
@@ -139,8 +139,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -169,8 +169,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -399,8 +399,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -424,8 +424,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -563,7 +563,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -594,8 +594,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -681,8 +681,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds2/layer1.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/rds2/layer1.py
@@ -319,8 +319,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -415,9 +415,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -450,8 +450,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -534,7 +534,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -653,8 +653,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2478,7 +2478,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2606,14 +2606,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2624,7 +2624,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2658,7 +2658,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2810,8 +2810,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/redshift/layer1.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
@@ -182,7 +182,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -238,7 +238,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(response.instancegroups[0].name, "Main instance group")
         self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
         self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
@@ -566,7 +566,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -598,7 +598,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.status.state, 'TERMINATED')
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
-        self.assertEqual(response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -836,7 +836,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -853,7 +853,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -871,11 +871,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -903,14 +903,14 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -932,7 +932,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1000,5 +1000,5 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster' },
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/crcmod/docs/source/conf.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/oauth2client/docs/conf.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/oauth2client/docs/conf.py
@@ -17,7 +17,7 @@ extensions = [
 ]
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 # General information about the project.
 project = u'oauth2client'

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/rsa/doc/conf.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/rsa/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Python-RSA'

--- a/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/six/documentation/conf.py
+++ b/frontend/yes/google-cloud-sdk/.install/.backup/platform/gsutil/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"

--- a/frontend/yes/google-cloud-sdk/lib/dns/rdataset.py
+++ b/frontend/yes/google-cloud-sdk/lib/dns/rdataset.py
@@ -169,7 +169,7 @@ class Rdataset(dns.set.Set):
 
     def to_text(self, name=None, origin=None, relativize=True,
                 override_rdclass=None, **kw):
-        """Convert the rdataset into DNS master file format.
+        """Convert the rdataset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/frontend/yes/google-cloud-sdk/lib/dns/rdtypes/ANY/SOA.py
+++ b/frontend/yes/google-cloud-sdk/lib/dns/rdtypes/ANY/SOA.py
@@ -22,7 +22,7 @@ import dns.name
 class SOA(dns.rdata.Rdata):
     """SOA record
 
-    @ivar mname: the SOA MNAME (master name) field
+    @ivar mname: the SOA MNAME (main name) field
     @type mname: dns.name.Name object
     @ivar rname: the SOA RNAME (responsible name) field
     @type rname: dns.name.Name object

--- a/frontend/yes/google-cloud-sdk/lib/dns/rrset.py
+++ b/frontend/yes/google-cloud-sdk/lib/dns/rrset.py
@@ -84,7 +84,7 @@ class RRset(dns.rdataset.Rdataset):
         return True
 
     def to_text(self, origin=None, relativize=True, **kw):
-        """Convert the RRset into DNS master file format.
+        """Convert the RRset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/frontend/yes/google-cloud-sdk/lib/dns/tokenizer.py
+++ b/frontend/yes/google-cloud-sdk/lib/dns/tokenizer.py
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Tokenize DNS master file format"""
+"""Tokenize DNS main file format"""
 
 import cStringIO
 import sys
@@ -47,7 +47,7 @@ class UngetBufferFull(dns.exception.DNSException):
     pass
 
 class Token(object):
-    """A DNS master file format token.
+    """A DNS main file format token.
 
     @ivar ttype: The token type
     @type ttype: int
@@ -156,7 +156,7 @@ class Token(object):
             raise IndexError
 
 class Tokenizer(object):
-    """A DNS master file format tokenizer.
+    """A DNS main file format tokenizer.
 
     A token is a (type, value) tuple, where I{type} is an int, and
     I{value} is a string.  The valid types are EOF, EOL, WHITESPACE,

--- a/frontend/yes/google-cloud-sdk/lib/dns/zone.py
+++ b/frontend/yes/google-cloud-sdk/lib/dns/zone.py
@@ -520,8 +520,8 @@ class Zone(object):
             raise NoNS
 
 
-class _MasterReader(object):
-    """Read a DNS master file
+class _MainReader(object):
+    """Read a DNS main file
 
     @ivar tok: The tokenizer
     @type tok: dns.tokenizer.Tokenizer object
@@ -569,7 +569,7 @@ class _MasterReader(object):
                 break
 
     def _rr_line(self):
-        """Process one line from a DNS master file."""
+        """Process one line from a DNS main file."""
         # Name
         if self.current_origin is None:
             raise UnknownOrigin
@@ -642,7 +642,7 @@ class _MasterReader(object):
         rds.add(rd, ttl)
 
     def read(self):
-        """Read a DNS master file and build a zone object.
+        """Read a DNS main file and build a zone object.
 
         @raises dns.zone.NoSOA: No SOA RR was found at the zone origin
         @raises dns.zone.NoNS: No NS RRset was found at the zone origin
@@ -704,7 +704,7 @@ class _MasterReader(object):
                                                            filename)
                         self.current_origin = new_origin
                     else:
-                        raise dns.exception.SyntaxError("Unknown master file directive '" + u + "'")
+                        raise dns.exception.SyntaxError("Unknown main file directive '" + u + "'")
                     continue
                 self.tok.unget(token)
                 self._rr_line()
@@ -721,12 +721,12 @@ class _MasterReader(object):
 def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=False, check_origin=True):
-    """Build a zone object from a master file format string.
+    """Build a zone object from a main file format string.
 
-    @param text: the master file format input
+    @param text: the main file format input
     @type text: string.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.
@@ -755,7 +755,7 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
     if filename is None:
         filename = '<string>'
     tok = dns.tokenizer.Tokenizer(text, filename)
-    reader = _MasterReader(tok, origin, rdclass, relativize, zone_factory,
+    reader = _MainReader(tok, origin, rdclass, relativize, zone_factory,
                            allow_include=allow_include,
                            check_origin=check_origin)
     reader.read()
@@ -764,12 +764,12 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
 def from_file(f, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=True, check_origin=True):
-    """Read a master file and build a zone object.
+    """Read a main file and build a zone object.
 
     @param f: file or string.  If I{f} is a string, it is treated
     as the name of a file to open.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/apitools/base/py/batch.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/apitools/base/py/batch.py
@@ -148,7 +148,7 @@ class BatchApiRequest(object):
         method_config, request, global_params=global_params,
         upload_config=upload_config)
 
-    # Create the request and add it to our master list.
+    # Create the request and add it to our main list.
     api_request = self.ApiCall(
         http_request, self.retryable_codes, service, method_config)
     self.api_requests.append(api_request)

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1/container_v1_client.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1/container_v1_client.py
@@ -113,7 +113,7 @@ class ContainerV1(base_api.BaseApiClient):
 
     def Create(self, request, global_params=None):
       """Creates a cluster, consisting of the specified number and type of Google.
-Compute Engine instances, plus a Kubernetes master endpoint.
+Compute Engine instances, plus a Kubernetes main endpoint.
 
 By default, the cluster is created in the project's
 [default network]('/compute/docs/networking#networks_1').

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1/container_v1_messages.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1/container_v1_messages.py
@@ -29,20 +29,20 @@ class Cluster(_messages.Message):
     createTime: [Output only] The time the cluster was created, in
       [RFC3339](href='https://www.ietf.org/rfc/rfc3339.txt) text format.
       @OutputOnly.
-    currentMasterVersion: [Output only] The current software version of the
-      master endpoint. @OutputOnly.
+    currentMainVersion: [Output only] The current software version of the
+      main endpoint. @OutputOnly.
     currentNodeVersion: [Output only] The current version of the node software
       components. If they are currently at different versions because they're
       in the process of being upgraded, this reflects the minimum version of
       any of them. @OutputOnly.
     description: An optional description of this cluster.
-    endpoint: [Output only] The IP address of this cluster's Kubernetes master
+    endpoint: [Output only] The IP address of this cluster's Kubernetes main
       endpoint. The endpoint can be accessed from the internet at
       `https://username:password@endpoint/`. @OutputOnly.  See the
-      `masterAuth` property of this resource for username and password
+      `mainAuth` property of this resource for username and password
       information.
     initialClusterVersion: [Output only] The software version of Kubernetes
-      master and kubelets used in the cluster when it was first created. The
+      main and kubelets used in the cluster when it was first created. The
       version can be upgraded over time. @OutputOnly.
     initialNodeCount: The number of nodes to create in this cluster. You must
       ensure that your Compute Engine [resource quota](/compute/docs/resource-
@@ -55,7 +55,7 @@ class Cluster(_messages.Message):
       Currently available options:  * "logging.googleapis.com" - the Google
       Cloud Logging service * "none" - no logs will be exported from the
       cluster * "" - default value; the default is "logging.googleapis.com"
-    masterAuth: The authentication information for accessing the master.
+    mainAuth: The authentication information for accessing the main.
     monitoringService: The monitoring service that the cluster should write
       metrics to. Currently available options:  * "monitoring.googleapis.com"
       - the Google Cloud Monitoring service * "none" - no metrics will be
@@ -97,7 +97,7 @@ class Cluster(_messages.Message):
       RUNNING: The RUNNING state indicates the cluster has been created and is
         fully usable.
       RECONCILING: The RECONCILING state indicates that some work is actively
-        being done on the cluster, such as upgrading the master or node
+        being done on the cluster, such as upgrading the main or node
         software. Details can be found in the statusMessage field.
       STOPPING: The STOPPING state indicates the cluster is being deleted.
       ERROR: The ERROR state indicates the cluster may be unusable. Details
@@ -112,7 +112,7 @@ class Cluster(_messages.Message):
 
   clusterIpv4Cidr = _messages.StringField(1)
   createTime = _messages.StringField(2)
-  currentMasterVersion = _messages.StringField(3)
+  currentMainVersion = _messages.StringField(3)
   currentNodeVersion = _messages.StringField(4)
   description = _messages.StringField(5)
   endpoint = _messages.StringField(6)
@@ -120,7 +120,7 @@ class Cluster(_messages.Message):
   initialNodeCount = _messages.IntegerField(8, variant=_messages.Variant.INT32)
   instanceGroupUrls = _messages.StringField(9, repeated=True)
   loggingService = _messages.StringField(10)
-  masterAuth = _messages.MessageField('MasterAuth', 11)
+  mainAuth = _messages.MessageField('MainAuth', 11)
   monitoringService = _messages.StringField(12)
   name = _messages.StringField(13)
   network = _messages.StringField(14)
@@ -137,7 +137,7 @@ class ClusterUpdate(_messages.Message):
   """ClusterUpdate describes an update to the cluster.
 
   Fields:
-    desiredMasterVersion: The Kubernetes version to change the master to
+    desiredMainVersion: The Kubernetes version to change the main to
       (typically an upgrade). Use "-" to upgrade to the latest version
       supported by the server.
     desiredNodeVersion: The Kubernetes version to change the nodes to
@@ -145,7 +145,7 @@ class ClusterUpdate(_messages.Message):
       supported by the server.
   """
 
-  desiredMasterVersion = _messages.StringField(1)
+  desiredMainVersion = _messages.StringField(1)
   desiredNodeVersion = _messages.StringField(2)
 
 
@@ -302,8 +302,8 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master endpoint.
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main endpoint.
   Authentication can be done using HTTP basic auth or using client
   certificates.
 
@@ -315,10 +315,10 @@ class MasterAuth(_messages.Message):
     clusterCaCertificate: [Output only] Base64 encoded public certificate that
       is the root of trust for the cluster. @OutputOnly.
     password: The password to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint. Because the master endpoint is open to
+      the Kubernetes main endpoint. Because the main endpoint is open to
       the internet, you should create a strong password.
     username: The username to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint.
+      the Kubernetes main endpoint.
   """
 
   clientCertificate = _messages.StringField(1)
@@ -377,7 +377,7 @@ class Operation(_messages.Message):
       TYPE_UNSPECIFIED: Not set.
       CREATE_CLUSTER: Cluster create.
       DELETE_CLUSTER: Cluster delete.
-      UPGRADE_MASTER: A master upgrade.
+      UPGRADE_MASTER: A main upgrade.
       UPGRADE_NODES: A node upgrade.
       REPAIR_CLUSTER: Cluster repair.
     """

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
@@ -178,11 +178,11 @@ class ContainerV1beta1(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes master instance.
+      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes main instance.
 
 The cluster is created in the project's default network.
 
-A firewall is added that allows traffic into port 443 on the master, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
+A firewall is added that allows traffic into port 443 on the main, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
 
 Finally, an entry is added to the project's global metadata indicating which CIDR range is being used by the cluster.
 
@@ -197,7 +197,7 @@ Finally, an entry is added to the project's global metadata indicating which CID
           config, request, global_params=global_params)
 
     def Delete(self, request, global_params=None):
-      """Deletes the cluster, including the Kubernetes master and all worker nodes.
+      """Deletes the cluster, including the Kubernetes main and all worker nodes.
 
 Firewalls and routes that were configured at cluster creation are also deleted.
 

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
@@ -18,7 +18,7 @@ class Cluster(_messages.Message):
     StatusValueValuesEnum: [Output only] The current status of this cluster.
 
   Fields:
-    clusterApiVersion: The API version of the Kubernetes master and kubelets
+    clusterApiVersion: The API version of the Kubernetes main and kubelets
       running in this cluster. Leave blank to pick up the latest stable
       release, or specify a version of the form "x.y.z". The Google Container
       Engine release notes lists the currently supported versions. If an
@@ -38,12 +38,12 @@ class Cluster(_messages.Message):
     enableCloudMonitoring: Whether metrics from the cluster should be made
       available via the Google Cloud Monitoring service.
     endpoint: [Output only] The IP address of this cluster's Kubernetes
-      master. The endpoint can be accessed from the internet at
-      https://username:password@endpoint/.  See the masterAuth property of
+      main. The endpoint can be accessed from the internet at
+      https://username:password@endpoint/.  See the mainAuth property of
       this resource for username and password information.
     instanceGroupUrls: [Output only] The resource URLs of [instance
       groups](/compute/docs/instance-groups/) associated with this cluster.
-    masterAuth: The authentication information for accessing the master.
+    mainAuth: The authentication information for accessing the main.
     name: The name of this cluster. The name must be unique within this
       project and zone, and can be up to 40 characters with the following
       restrictions:   - Lowercase letters, numbers, and hyphens only. - Must
@@ -56,7 +56,7 @@ class Cluster(_messages.Message):
       node for hosting containers.
     numNodes: The number of nodes to create in this cluster. You must ensure
       that your Compute Engine resource quota is sufficient for this number of
-      instances plus one (to include the master). You must also have available
+      instances plus one (to include the main). You must also have available
       firewall and routes quota.
     selfLink: [Output only] Server-defined URL for the resource.
     servicesIpv4Cidr: [Output only] The IP address range of the Kubernetes
@@ -91,7 +91,7 @@ class Cluster(_messages.Message):
   enableCloudMonitoring = _messages.BooleanField(6)
   endpoint = _messages.StringField(7)
   instanceGroupUrls = _messages.StringField(8, repeated=True)
-  masterAuth = _messages.MessageField('MasterAuth', 9)
+  mainAuth = _messages.MessageField('MainAuth', 9)
   name = _messages.StringField(10)
   network = _messages.StringField(11)
   nodeConfig = _messages.MessageField('NodeConfig', 12)
@@ -262,14 +262,14 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master. Authentication
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main. Authentication
   is either done using HTTP basic authentication or using a bearer token.
 
   Fields:
-    bearerToken: The token used to authenticate API requests to the master.
+    bearerToken: The token used to authenticate API requests to the main.
       The token is to be included in an HTTP Authorization Header in all
-      requests to the master endpoint. The format of the header is:
+      requests to the main endpoint. The format of the header is:
       "Authorization: Bearer ".
     clientCertificate: [Output only] Base64 encoded public certificate used by
       clients to authenticate to the cluster endpoint.
@@ -278,10 +278,10 @@ class MasterAuth(_messages.Message):
     clusterCaCertificate: [Output only] Base64 encoded public certificate that
       is the root of trust for the cluster.
     password: The password to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint. Because the master endpoint is open to
+      the Kubernetes main endpoint. Because the main endpoint is open to
       the internet, you should create a strong password.
     user: The username to use for HTTP basic authentication when accessing the
-      Kubernetes master endpoint.
+      Kubernetes main endpoint.
   """
 
   bearerToken = _messages.StringField(1)

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta2/container_v1beta2_client.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta2/container_v1beta2_client.py
@@ -190,7 +190,7 @@ class ContainerV1beta2(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes master endpoint.
+      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes main endpoint.
 
 By default, the cluster is created in the project's default network.
 

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta2/container_v1beta2_messages.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/container/v1beta2/container_v1beta2_messages.py
@@ -24,8 +24,8 @@ class Cluster(_messages.Message):
       172.16.0.0/12.
     creationTimestamp: [Output only] The time the cluster was created, in
       RFC3339 text format.
-    currentMasterVersion: [Output only] The current software version of the
-      master endpoint.
+    currentMainVersion: [Output only] The current software version of the
+      main endpoint.
     currentNodeVersion: [Output only] The current version of the node software
       components. If they are currently at different versions because they're
       in the process of being upgraded, this reflects the minimum version of
@@ -37,14 +37,14 @@ class Cluster(_messages.Message):
       components themselves.
     enableCloudMonitoring: Whether metrics from the cluster should be made
       available via the Google Cloud Monitoring service.
-    endpoint: [Output only] The IP address of this cluster's Kubernetes master
+    endpoint: [Output only] The IP address of this cluster's Kubernetes main
       endpoint. The endpoint can be accessed from the internet at
-      https://username:password@endpoint/.  See the masterAuth property of
+      https://username:password@endpoint/.  See the mainAuth property of
       this resource for username and password information.
     initialClusterVersion: [Output only] The software version of Kubernetes
-      master and kubelets used in the cluster when it was first created. The
+      main and kubelets used in the cluster when it was first created. The
       version can be upgraded over time.
-    masterAuth: The authentication information for accessing the master.
+    mainAuth: The authentication information for accessing the main.
     name: The name of this cluster. The name must be unique within this
       project and zone, and can be up to 40 characters with the following
       restrictions:   - Lowercase letters, numbers, and hyphens only. - Must
@@ -88,14 +88,14 @@ class Cluster(_messages.Message):
 
   containerIpv4Cidr = _messages.StringField(1)
   creationTimestamp = _messages.StringField(2)
-  currentMasterVersion = _messages.StringField(3)
+  currentMainVersion = _messages.StringField(3)
   currentNodeVersion = _messages.StringField(4)
   description = _messages.StringField(5)
   enableCloudLogging = _messages.BooleanField(6)
   enableCloudMonitoring = _messages.BooleanField(7)
   endpoint = _messages.StringField(8)
   initialClusterVersion = _messages.StringField(9)
-  masterAuth = _messages.MessageField('MasterAuth', 10)
+  mainAuth = _messages.MessageField('MainAuth', 10)
   name = _messages.StringField(11)
   network = _messages.StringField(12)
   nodeConfig = _messages.MessageField('NodeConfig', 13)
@@ -112,13 +112,13 @@ class ClusterUpdate(_messages.Message):
   """A ClusterUpdate object.
 
   Fields:
-    desiredMasterVersion: The Kubernetes version to change the master to
+    desiredMainVersion: The Kubernetes version to change the main to
       (typically an upgrade).
     desiredNodeVersion: The Kubernetes version to change the nodes to
       (typically an upgrade).
   """
 
-  desiredMasterVersion = _messages.MessageField('ClusterVersion', 1)
+  desiredMainVersion = _messages.MessageField('ClusterVersion', 1)
   desiredNodeVersion = _messages.MessageField('ClusterVersion', 2)
 
 
@@ -308,16 +308,16 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master endpoint.
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main endpoint.
   Authentication is done using HTTP basic authentication.
 
   Fields:
     password: The password to use for HTTP basic authentication when accessing
-      the Kubernetes master endpoint. Because the master endpoint is open to
+      the Kubernetes main endpoint. Because the main endpoint is open to
       the internet, you should create a strong password.
     user: The username to use for HTTP basic authentication when accessing the
-      Kubernetes master endpoint.
+      Kubernetes main endpoint.
   """
 
   password = _messages.StringField(1)
@@ -371,12 +371,12 @@ class Operation(_messages.Message):
     Values:
       createCluster: <no description>
       deleteCluster: <no description>
-      upgradeMaster: <no description>
+      upgradeMain: <no description>
       upgradeNodes: <no description>
     """
     createCluster = 0
     deleteCluster = 1
-    upgradeMaster = 2
+    upgradeMain = 2
     upgradeNodes = 3
 
   class StatusValueValuesEnum(_messages.Enum):

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
@@ -150,7 +150,7 @@ class DatabaseInstance(_messages.Message):
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     project: The project ID of the project containing the Cloud SQL instance.
@@ -179,7 +179,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 6, repeated=True)
   ipv6Address = _messages.StringField(7)
   kind = _messages.StringField(8, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(9)
+  mainInstanceName = _messages.StringField(9)
   maxDiskSize = _messages.IntegerField(10)
   project = _messages.StringField(11)
   region = _messages.StringField(12)

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudapis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudapis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
@@ -187,13 +187,13 @@ class DatabaseInstance(_messages.Message):
     etag: HTTP 1.1 Entity tag for the resource.
     instanceType: The instance type. This can be one of the following.
       CLOUD_SQL_INSTANCE: A Cloud SQL instance that is not replicating from a
-      master. ON_PREMISES_INSTANCE: An instance running on the customer's
+      main. ON_PREMISES_INSTANCE: An instance running on the customer's
       premises. READ_REPLICA_INSTANCE: A Cloud SQL instance configured as a
       read-replica.
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     name: Name of the Cloud SQL instance. This does not include the project
@@ -205,7 +205,7 @@ class DatabaseInstance(_messages.Message):
       west1. Defaults to us-central. The region can not be changed after
       instance creation.
     replicaConfiguration: Configuration specific to read-replicas replicating
-      from on-premises masters.
+      from on-premises mains.
     replicaNames: The replicas of the instance.
     selfLink: The URI of this resource.
     serverCaCert: SSL configuration.
@@ -228,7 +228,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 5, repeated=True)
   ipv6Address = _messages.StringField(6)
   kind = _messages.StringField(7, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(8)
+  mainInstanceName = _messages.StringField(8)
   maxDiskSize = _messages.IntegerField(9)
   name = _messages.StringField(10)
   onPremisesConfiguration = _messages.MessageField('OnPremisesConfiguration', 11)
@@ -497,24 +497,24 @@ class MySqlReplicaConfiguration(_messages.Message):
 
   Fields:
     caCertificate: PEM representation of the trusted CA's x509 certificate.
-    clientCertificate: PEM representation of the slave's x509 certificate.
-    clientKey: PEM representation of the slave's private key. The
+    clientCertificate: PEM representation of the subordinate's x509 certificate.
+    clientKey: PEM representation of the subordinate's private key. The
       corresponsing public key is encoded in the client's certificate.
     connectRetryInterval: Seconds to wait between connect retries. MySQL's
       default is 60 seconds.
     dumpFilePath: Path to a SQL dump file in Google Cloud Storage from which
-      the slave instance is to be created. The URI is in the form
+      the subordinate instance is to be created. The URI is in the form
       gs://bucketName/fileName. Compressed gzip files (.gz) are also
       supported. Dumps should have the binlog co-ordinates from which
-      replication should begin. This can be accomplished by setting --master-
+      replication should begin. This can be accomplished by setting --main-
       data to 1 when using mysqldump.
     kind: This is always sql#mysqlReplicaConfiguration.
-    masterHeartbeatPeriod: Interval in milliseconds between replication
+    mainHeartbeatPeriod: Interval in milliseconds between replication
       heartbeats.
     password: The password for the replication connection.
     sslCipher: A list of permissible ciphers to use for SSL encryption.
     username: The username for the replication connection.
-    verifyServerCertificate: Whether or not to check the master's Common Name
+    verifyServerCertificate: Whether or not to check the main's Common Name
       value in the certificate that it sends during the SSL handshake.
   """
 
@@ -524,7 +524,7 @@ class MySqlReplicaConfiguration(_messages.Message):
   connectRetryInterval = _messages.IntegerField(4, variant=_messages.Variant.INT32)
   dumpFilePath = _messages.StringField(5)
   kind = _messages.StringField(6, default=u'sql#mysqlReplicaConfiguration')
-  masterHeartbeatPeriod = _messages.IntegerField(7)
+  mainHeartbeatPeriod = _messages.IntegerField(7)
   password = _messages.StringField(8)
   sslCipher = _messages.StringField(9)
   username = _messages.StringField(10)
@@ -638,16 +638,16 @@ class OperationsListResponse(_messages.Message):
 
 
 class ReplicaConfiguration(_messages.Message):
-  """Read-replica configuration for connecting to the master.
+  """Read-replica configuration for connecting to the main.
 
   Fields:
     kind: This is always sql#replicaConfiguration.
     mysqlReplicaConfiguration: MySQL specific configuration when replicating
-      from a MySQL on-premises master. Replication configuration information
+      from a MySQL on-premises main. Replication configuration information
       such as the username, password, certificates, and keys are not stored in
       the instance metadata. The configuration information is used only to set
       up the replication connection and is stored by MySQL in a file named
-      master.info in the data directory.
+      main.info in the data directory.
   """
 
   kind = _messages.StringField(1, default=u'sql#replicaConfiguration')

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/container/commands/clusters/upgrade.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/container/commands/clusters/upgrade.py
@@ -32,7 +32,7 @@ class UpgradeBeta(base.Command):
         help='The kubernetes release version to change the cluster to.'
         ' Omit to upgrade to the latest version offered by the server.')
     parser.add_argument(
-        '--master',
+        '--main',
         help=argparse.SUPPRESS,
         action='store_true')
     parser.add_argument(
@@ -64,8 +64,8 @@ class UpgradeBeta(base.Command):
 
     options = api_adapter.UpdateClusterOptions(
         version=args.cluster_version,
-        update_master=args.master,
-        update_nodes=(not args.master))
+        update_main=args.main,
+        update_nodes=(not args.main))
 
     try:
       op_ref = adapter.UpdateCluster(cluster_ref, options)

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/container/lib/api_adapter.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/container/lib/api_adapter.py
@@ -276,10 +276,10 @@ class UpdateClusterOptions(object):
 
   def __init__(self,
                version=None,
-               update_master=None,
+               update_main=None,
                update_nodes=None):
     self.version = version
-    self.update_master = bool(update_master)
+    self.update_main = bool(update_main)
     self.update_nodes = bool(update_nodes)
 
 
@@ -290,7 +290,7 @@ class V1Adapter(APIAdapter):
     return cluster_ref.zone
 
   def Version(self, cluster):
-    return cluster.currentMasterVersion
+    return cluster.currentMainVersion
 
   def PrintClusters(self, clusters):
     list_printer.PrintResourceList(
@@ -316,7 +316,7 @@ class V1Adapter(APIAdapter):
         name=cluster_ref.clusterId,
         initialNodeCount=options.num_nodes,
         nodeConfig=node_config,
-        masterAuth=self.messages.MasterAuth(username=options.user,
+        mainAuth=self.messages.MainAuth(username=options.user,
                                             password=options.password))
     if options.cluster_version:
       cluster.initialClusterVersion = options.cluster_version
@@ -345,9 +345,9 @@ class V1Adapter(APIAdapter):
     if options.update_nodes:
       update = self.messages.ClusterUpdate(
           desiredNodeVersion=options.version)
-    elif options.update_master:
+    elif options.update_main:
       update = self.messages.ClusterUpdate(
-          desiredMasterVersion=options.version)
+          desiredMainVersion=options.version)
 
     op = self.client.projects_zones_clusters.Update(
         self.messages.ContainerProjectsZonesClustersUpdateRequest(
@@ -423,7 +423,7 @@ class V1beta1Adapter(APIAdapter):
             name=cluster_ref.clusterId,
             numNodes=options.num_nodes,
             nodeConfig=node_config,
-            masterAuth=self.messages.MasterAuth(user=options.user,
+            mainAuth=self.messages.MainAuth(user=options.user,
                                                 password=options.password),
             enableCloudLogging=options.enable_cloud_logging))
     if options.cluster_version:

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/container/lib/util.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/container/lib/util.py
@@ -71,7 +71,7 @@ def IsVersionOlderThan(first, second):
   return dist_version.LooseVersion(first) < dist_version.LooseVersion(second)
 
 
-KMASTER_NAME_FORMAT = 'k8s-{cluster_name}-master'
+KMASTER_NAME_FORMAT = 'k8s-{cluster_name}-main'
 # These are determined by the version of kubernetes the cluster is running.
 # This needs kept up to date when validating new cluster api versions.
 KMASTER_LEGACY_CERT_DIRECTORY = '/usr/share/nginx'
@@ -84,14 +84,14 @@ KMASTER_CERT_FILES = [KMASTER_CLIENT_KEY, KMASTER_CLIENT_CERT,
                       KMASTER_CERT_AUTHORITY]
 
 
-def GetKmasterCertDirectory(version):
-  """Returns the directory on the Kubernetes master where SSL certs are stored.
+def GetKmainCertDirectory(version):
+  """Returns the directory on the Kubernetes main where SSL certs are stored.
 
   Args:
     version: str, Kubernetes version (e.g. "0.4.4" or "0.5.2").
 
   Returns:
-    str, the path to SSL certs on the Kubernetes master.
+    str, the path to SSL certs on the Kubernetes main.
   """
   if IsVersionOlderThan(version, '0.5'):
     return KMASTER_LEGACY_CERT_DIRECTORY
@@ -250,7 +250,7 @@ class ClusterConfig(object):
         'project_id': project_id,
         'server': 'https://' + cluster.endpoint,
     }
-    auth = cluster.masterAuth
+    auth = cluster.mainAuth
     version = cls._ClusterVersion(cluster)
     if auth.clientCertificate and auth.clientKey and auth.clusterCaCertificate:
       kwargs['ca_data'] = auth.clusterCaCertificate
@@ -385,7 +385,7 @@ class ClusterConfig(object):
   def _FetchCertFiles(cls, cluster, project_id, cli):
     """Call into gcloud.compute.copy_files to copy certs from cluster.
 
-    Copies cert files from Kubernetes master into local config directory
+    Copies cert files from Kubernetes main into local config directory
     for the provided cluster.
 
     Args:
@@ -398,7 +398,7 @@ class ClusterConfig(object):
     instance_name = KMASTER_NAME_FORMAT.format(cluster_name=cluster.name)
 
     version = cls._ClusterVersion(cluster)
-    cert_dir = GetKmasterCertDirectory(version)
+    cert_dir = GetKmainCertDirectory(version)
     paths = [os.path.join(cert_dir, cert_file) for
              cert_file in KMASTER_CERT_FILES]
     # Put all the paths together in the same CLI argument so that SCP copies all
@@ -411,14 +411,14 @@ class ClusterConfig(object):
     config_dir = cls.GetConfigDir(cluster.name, cluster.zone, project_id)
     file_utils.MakeDir(config_dir)
     log.out.Print('Using gcloud compute copy-files to fetch ssl certs from '
-                  'cluster master...')
+                  'cluster main...')
     try:
       cli.Execute(['compute', 'copy-files', '--zone=' + cluster.zone,
                    remote_file_paths, config_dir])
       return True
     except exceptions.ToolException as error:
       log.error(
-          'Fetching ssl certs from cluster master failed:\n\n%s\n\n'
+          'Fetching ssl certs from cluster main failed:\n\n%s\n\n'
           'You can still interact with the cluster, but you may see a warning '
           'that certificate checking is disabled.',
           error)

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/dns/lib/import_util.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/dns/lib/import_util.py
@@ -48,7 +48,7 @@ def _SOATranslation(rdata, origin):
 
   Returns:
     str, The translation of the given SOA rdata which includes all the required
-    SOA fields. Note that the master NS name is left in a substitutable form
+    SOA fields. Note that the main NS name is left in a substitutable form
     because it is always provided by Cloud DNS.
   """
   return ' '.join(
@@ -182,7 +182,7 @@ def RecordSetsFromZoneFile(zone_file, domain):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     zone file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   zone_contents = zone.from_file(zone_file, domain, check_origin=False)
@@ -204,7 +204,7 @@ def RecordSetsFromYamlFile(yaml_file):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     yaml file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   record_sets = {}
@@ -224,7 +224,7 @@ def RecordSetsFromYamlFile(yaml_file):
     record_set.rrdatas = yaml_record_set['rrdatas']
 
     if rdata_type is rdatatype.SOA:
-      # Make master NS name substitutable.
+      # Make main NS name substitutable.
       record_set.rrdatas[0] = re.sub(r'\S+', '{0}', record_set.rrdatas[0],
                                      count=1)
 
@@ -252,14 +252,14 @@ def _RecordSetCopy(record_set):
 
 
 def _SOAReplacement(current_record, record_to_be_imported):
-  """Returns the replacement SOA record with restored master NS name.
+  """Returns the replacement SOA record with restored main NS name.
 
   Args:
     current_record: ResourceRecordSet, Current record-set.
     record_to_be_imported: ResourceRecordSet, Record-set to be imported.
 
   Returns:
-    ResourceRecordSet, the replacement SOA record with restored master NS name.
+    ResourceRecordSet, the replacement SOA record with restored main NS name.
   """
   replacement = _RecordSetCopy(record_to_be_imported)
   replacement.rrdatas[0] = replacement.rrdatas[0].format(

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/gcloud/sdktools/root/init.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/gcloud/sdktools/root/init.py
@@ -45,7 +45,7 @@ class Init(base.Command):
           git repository associated with PROJECT. This repository will
           automatically be connected to Google, and it will use the credentials
           indicated as _active_ by `gcloud auth list`. Pushing
-          to the origin's _master_ branch will trigger an App Engine deployment
+          to the origin's _main_ branch will trigger an App Engine deployment
           using the contents of that branch.
 
           **Note: this command will be changing soon. Consider using
@@ -61,7 +61,7 @@ class Init(base.Command):
             $ cd MYPROJECT/default
             $ git pull
               https://github.com/GoogleCloudPlatform/appengine-helloworld-python
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/source/commands/clone.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/source/commands/clone.py
@@ -26,7 +26,7 @@ class Clone(base.Command):
           this `{command}` will clone the Google-hosted git repository
           associated with PROJECT. This repository will automatically be
           connected to Google, and it will use the credentials indicated as
-          _active_ by `gcloud auth list`. Pushing to the origin's _master_
+          _active_ by `gcloud auth list`. Pushing to the origin's _main_
           branch will trigger an App Engine deployment using the contents
           of that branch.
       """,
@@ -39,7 +39,7 @@ class Clone(base.Command):
             $ cd REPOSITORY_NAME
             $ git pull
               https://github.com/GoogleCloudPlatform/appengine-helloworld-python
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/sql/tools/instances/create.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/sql/tools/instances/create.py
@@ -98,11 +98,11 @@ class Create(base.Command):
         'instance',
         help='Cloud SQL instance ID.')
     parser.add_argument(
-        '--master-instance-name',
+        '--main-instance-name',
         required=False,
-        help='Name of the instance which will act as master in the replication '
+        help='Name of the instance which will act as main in the replication '
         'setup. The newly created instance will be a read replica of the '
-        'specified master instance.')
+        'specified main instance.')
     parser.add_argument(
         '--pricing-plan',
         '-p',
@@ -181,7 +181,7 @@ class Create(base.Command):
 
     instance_resource = util.ConstructInstanceFromArgs(sql_messages, args)
 
-    if args.master_instance_name:
+    if args.main_instance_name:
       replication = 'ASYNCHRONOUS'
       activation_policy = 'ALWAYS'
     else:

--- a/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/sql/util.py
+++ b/frontend/yes/google-cloud-sdk/lib/googlecloudsdk/sql/util.py
@@ -305,7 +305,7 @@ def ConstructInstanceFromArgs(sql_messages, args, original=None):
   instance_resource = sql_messages.DatabaseInstance(
       region=region,
       databaseVersion=database_version,
-      masterInstanceName=getattr(args, 'master_instance_name', None),
+      mainInstanceName=getattr(args, 'main_instance_name', None),
       settings=settings)
 
   return instance_resource

--- a/frontend/yes/google-cloud-sdk/lib/jinja2/pkg_resources.py
+++ b/frontend/yes/google-cloud-sdk/lib/jinja2/pkg_resources.py
@@ -2693,7 +2693,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 
 try:

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/google/appengine/_internal/django/conf/global_settings.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/google/appengine/_internal/django/conf/global_settings.py
@@ -208,7 +208,7 @@ ADMIN_MEDIA_PREFIX = '/media/'
 
 # Default e-mail address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/google/appengine/datastore/datastore_sqlite_stub.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/google/appengine/datastore/datastore_sqlite_stub.py
@@ -668,7 +668,7 @@ class DatastoreSqliteStub(datastore_stub_util.BaseDatastore,
       datastore_stub_util.BaseDatastore.Clear(self)
       datastore_stub_util.DatastoreStub.Clear(self)
       c = conn.execute(
-          "SELECT tbl_name FROM sqlite_master WHERE type = 'table'")
+          "SELECT tbl_name FROM sqlite_main WHERE type = 'table'")
       for row in c.fetchall():
         conn.execute('DROP TABLE "%s"' % row)
     finally:

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/argparse/doc/source/conf.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/argparse/doc/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'argparse'

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/distutils/distutils/command/install.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/distutils/distutils/command/install.py
@@ -239,7 +239,7 @@ class install (Command):
 
     def finalize_options (self):
 
-        # This method (and its pliant slaves, like 'finalize_unix()',
+        # This method (and its pliant subordinates, like 'finalize_unix()',
         # 'finalize_other()', and 'select_scheme()') is where the default
         # installation directories for modules, extension modules, and
         # anything else we care to install from a Python module

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/conf/global_settings.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/conf/global_settings.py
@@ -154,7 +154,7 @@ ADMIN_MEDIA_PREFIX = '/media/'
 
 # Default e-mail address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/db/backends/sqlite3/introspection.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/db/backends/sqlite3/introspection.py
@@ -5,7 +5,7 @@ def get_table_list(cursor):
     # Skip the sqlite_sequence system table used for autoincrement key
     # generation.
     cursor.execute("""
-        SELECT name FROM sqlite_master
+        SELECT name FROM sqlite_main
         WHERE type='table' AND NOT name='sqlite_sequence'
         ORDER BY name""")
     return [row[0] for row in cursor.fetchall()]

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/test/client.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/test/client.py
@@ -125,7 +125,7 @@ class Client:
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/test/doctest.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-0.96/django/test/doctest.py
@@ -1442,7 +1442,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1736,7 +1736,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1805,13 +1805,13 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if isprivate is not None:
         warnings.warn("the isprivate argument is deprecated; "
@@ -1847,10 +1847,10 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1923,13 +1923,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -1965,10 +1965,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/conf/global_settings.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/conf/global_settings.py
@@ -208,7 +208,7 @@ ADMIN_MEDIA_PREFIX = '/media/'
 
 # Default e-mail address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/db/backends/sqlite3/introspection.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/db/backends/sqlite3/introspection.py
@@ -46,7 +46,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type='table' AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -66,7 +66,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -84,7 +84,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchone()
             if not result:
                 continue

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/test/_doctest.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/test/_doctest.py
@@ -1466,7 +1466,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1760,7 +1760,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1829,13 +1829,13 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if isprivate is not None:
         warnings.warn("the isprivate argument is deprecated; "
@@ -1871,10 +1871,10 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1947,13 +1947,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -1989,10 +1989,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/test/client.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.2/django/test/client.py
@@ -207,7 +207,7 @@ class Client(object):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/conf/global_settings.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/conf/global_settings.py
@@ -209,7 +209,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default e-mail address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/db/backends/sqlite3/introspection.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/db/backends/sqlite3/introspection.py
@@ -46,7 +46,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type='table' AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -66,7 +66,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -84,7 +84,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/test/_doctest.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/test/_doctest.py
@@ -1466,7 +1466,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1760,7 +1760,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1829,13 +1829,13 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if isprivate is not None:
         warnings.warn("the isprivate argument is deprecated; "
@@ -1871,10 +1871,10 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1947,13 +1947,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -1989,10 +1989,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/test/client.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.3/django/test/client.py
@@ -361,7 +361,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/conf/global_settings.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/conf/global_settings.py
@@ -215,7 +215,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/contrib/localflavor/mk/forms.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/contrib/localflavor/mk/forms.py
@@ -39,10 +39,10 @@ class MKMunicipalitySelect(Select):
 
 class UMCNField(RegexField):
     """
-    A form field that validates input as a unique master citizen
+    A form field that validates input as a unique main citizen
     number.
 
-    The format of the unique master citizen number has been kept the same from
+    The format of the unique main citizen number has been kept the same from
     Yugoslavia. It is still in use in other countries as well, it is not applicable
     solely in Macedonia. For more information see:
     https://secure.wikimedia.org/wikipedia/en/wiki/Unique_Master_Citizen_Number

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/contrib/localflavor/mk/models.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/contrib/localflavor/mk/models.py
@@ -32,7 +32,7 @@ class MKMunicipalityField(CharField):
 
 class UMCNField(CharField):
 
-    description = _("Unique master citizen number (13 digits)")
+    description = _("Unique main citizen number (13 digits)")
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 13

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/db/backends/sqlite3/introspection.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/db/backends/sqlite3/introspection.py
@@ -46,7 +46,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type='table' AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -66,7 +66,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -84,7 +84,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -111,7 +111,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -162,7 +162,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
         for field_desc in results.split(','):

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/test/_doctest.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/test/_doctest.py
@@ -1431,7 +1431,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1725,7 +1725,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1787,13 +1787,13 @@ def testmod(m=None, name=None, globs=None, verbose=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     # If no module was given, then use __main__.
     if m is None:
@@ -1824,10 +1824,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1905,13 +1905,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -1947,10 +1947,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/test/client.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.4/django/test/client.py
@@ -361,7 +361,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/conf/global_settings.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/conf/global_settings.py
@@ -218,7 +218,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/contrib/localflavor/mk/forms.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/contrib/localflavor/mk/forms.py
@@ -39,10 +39,10 @@ class MKMunicipalitySelect(Select):
 
 class UMCNField(RegexField):
     """
-    A form field that validates input as a unique master citizen
+    A form field that validates input as a unique main citizen
     number.
 
-    The format of the unique master citizen number has been kept the same from
+    The format of the unique main citizen number has been kept the same from
     Yugoslavia. It is still in use in other countries as well, it is not applicable
     solely in Macedonia. For more information see:
     https://secure.wikimedia.org/wikipedia/en/wiki/Unique_Master_Citizen_Number

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/contrib/localflavor/mk/models.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/contrib/localflavor/mk/models.py
@@ -32,7 +32,7 @@ class MKMunicipalityField(CharField):
 
 class UMCNField(CharField):
 
-    description = _("Unique master citizen number (13 digits)")
+    description = _("Unique main citizen number (13 digits)")
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 13

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/db/backends/sqlite3/introspection.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/db/backends/sqlite3/introspection.py
@@ -53,7 +53,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type='table' AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -73,7 +73,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -91,7 +91,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -118,7 +118,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -163,7 +163,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
         for field_desc in results.split(','):

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/test/_doctest.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/test/_doctest.py
@@ -1521,7 +1521,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1815,7 +1815,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1877,13 +1877,13 @@ def testmod(m=None, name=None, globs=None, verbose=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     # If no module was given, then use __main__.
     if m is None:
@@ -1914,10 +1914,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1995,13 +1995,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -2037,10 +2037,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/test/client.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/django-1.5/django/test/client.py
@@ -386,7 +386,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/grizzled/grizzled/db/sqlite.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/grizzled/grizzled/db/sqlite.py
@@ -49,7 +49,7 @@ class SQLite3Driver(DBDriver):
         return RDBMSMetadata('SQLite', 'SQLite 3', sqlite3.sqlite_version)
 
     def get_tables(self, cursor):
-        cursor.execute("select name from sqlite_master where type = 'table'")
+        cursor.execute("select name from sqlite_main where type = 'table'")
         table_names = []
         rs = cursor.fetchone()
         while rs is not None:

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/docs/conf.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/docs/conf.py
@@ -31,8 +31,8 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General substitutions.
 project = 'Jinja2'

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/examples/basic/test.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/examples/basic/test.py
@@ -3,7 +3,7 @@ from jinja2.loaders import DictLoader
 
 env = Environment(loader=DictLoader({
 'child.html': u'''\
-{% extends master_layout or 'master.html' %}
+{% extends main_layout or 'main.html' %}
 {% include helpers = 'helpers.html' %}
 {% macro get_the_answer() %}42{% endmacro %}
 {% title = 'Hello World' %}
@@ -12,7 +12,7 @@ env = Environment(loader=DictLoader({
     {{ helpers.conspirate() }}
 {% endblock %}
 ''',
-'master.html': u'''\
+'main.html': u'''\
 <!doctype html>
 <title>{{ title }}</title>
 {% block body %}{% endblock %}

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/jinja2/testsuite/ext.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/jinja2/testsuite/ext.py
@@ -32,9 +32,9 @@ _gettext_re = re.compile(r'_\((.*?)\)(?s)')
 
 
 i18n_templates = {
-    'master.html': '<title>{{ page_title|default(_("missing")) }}</title>'
+    'main.html': '<title>{{ page_title|default(_("missing")) }}</title>'
                    '{% block body %}{% endblock %}',
-    'child.html': '{% extends "master.html" %}{% block body %}'
+    'child.html': '{% extends "main.html" %}{% block body %}'
                   '{% trans %}watch out{% endtrans %}{% endblock %}',
     'plural.html': '{% trans user_count %}One user online{% pluralize %}'
                    '{{ user_count }} users online{% endtrans %}',
@@ -42,9 +42,9 @@ i18n_templates = {
 }
 
 newstyle_i18n_templates = {
-    'master.html': '<title>{{ page_title|default(_("missing")) }}</title>'
+    'main.html': '<title>{{ page_title|default(_("missing")) }}</title>'
                    '{% block body %}{% endblock %}',
-    'child.html': '{% extends "master.html" %}{% block body %}'
+    'child.html': '{% extends "main.html" %}{% block body %}'
                   '{% trans %}watch out{% endtrans %}{% endblock %}',
     'plural.html': '{% trans user_count %}One user online{% pluralize %}'
                    '{{ user_count }} users online{% endtrans %}',

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/jinja2/testsuite/inheritance.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/jinja2-2.6/jinja2/testsuite/inheritance.py
@@ -121,41 +121,41 @@ class InheritanceTestCase(JinjaTestCase):
 
     def test_dynamic_inheritance(self):
         env = Environment(loader=DictLoader({
-            'master1': 'MASTER1{% block x %}{% endblock %}',
-            'master2': 'MASTER2{% block x %}{% endblock %}',
-            'child': '{% extends master %}{% block x %}CHILD{% endblock %}'
+            'main1': 'MASTER1{% block x %}{% endblock %}',
+            'main2': 'MASTER2{% block x %}{% endblock %}',
+            'child': '{% extends main %}{% block x %}CHILD{% endblock %}'
         }))
         tmpl = env.get_template('child')
         for m in range(1, 3):
-            assert tmpl.render(master='master%d' % m) == 'MASTER%dCHILD' % m
+            assert tmpl.render(main='main%d' % m) == 'MASTER%dCHILD' % m
 
     def test_multi_inheritance(self):
         env = Environment(loader=DictLoader({
-            'master1': 'MASTER1{% block x %}{% endblock %}',
-            'master2': 'MASTER2{% block x %}{% endblock %}',
-            'child': '''{% if master %}{% extends master %}{% else %}{% extends
-                        'master1' %}{% endif %}{% block x %}CHILD{% endblock %}'''
+            'main1': 'MASTER1{% block x %}{% endblock %}',
+            'main2': 'MASTER2{% block x %}{% endblock %}',
+            'child': '''{% if main %}{% extends main %}{% else %}{% extends
+                        'main1' %}{% endif %}{% block x %}CHILD{% endblock %}'''
         }))
         tmpl = env.get_template('child')
-        assert tmpl.render(master='master2') == 'MASTER2CHILD'
-        assert tmpl.render(master='master1') == 'MASTER1CHILD'
+        assert tmpl.render(main='main2') == 'MASTER2CHILD'
+        assert tmpl.render(main='main1') == 'MASTER1CHILD'
         assert tmpl.render() == 'MASTER1CHILD'
 
     def test_scoped_block(self):
         env = Environment(loader=DictLoader({
-            'master.html': '{% for item in seq %}[{% block item scoped %}'
+            'main.html': '{% for item in seq %}[{% block item scoped %}'
                            '{% endblock %}]{% endfor %}'
         }))
-        t = env.from_string('{% extends "master.html" %}{% block item %}'
+        t = env.from_string('{% extends "main.html" %}{% block item %}'
                             '{{ item }}{% endblock %}')
         assert t.render(seq=range(5)) == '[0][1][2][3][4]'
 
     def test_super_in_scoped_block(self):
         env = Environment(loader=DictLoader({
-            'master.html': '{% for item in seq %}[{% block item scoped %}'
+            'main.html': '{% for item in seq %}[{% block item scoped %}'
                            '{{ item }}{% endblock %}]{% endfor %}'
         }))
-        t = env.from_string('{% extends "master.html" %}{% block item %}'
+        t = env.from_string('{% extends "main.html" %}{% block item %}'
                             '{{ super() }}|{{ item * 2 }}{% endblock %}')
         assert t.render(seq=range(5)) == '[0|0][1|2][2|4][3|6][4|8]'
 

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/setuptools-0.6c11/pkg_resources.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/setuptools-0.6c11/pkg_resources.py
@@ -2590,7 +2590,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 try:
     # Does the main program list any requirements?

--- a/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/setuptools-0.6c11/setuptools/tests/doctest.py
+++ b/frontend/yes/google-cloud-sdk/platform/google_appengine/lib/setuptools-0.6c11/setuptools/tests/doctest.py
@@ -1452,7 +1452,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1746,7 +1746,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1815,13 +1815,13 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if isprivate is not None:
         warnings.warn("the isprivate argument is deprecated; "
@@ -1857,10 +1857,10 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1933,13 +1933,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -1975,10 +1975,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
@@ -126,7 +126,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://developers.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
@@ -159,7 +159,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/apitools/run_pylint.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/apitools/run_pylint.py
@@ -103,9 +103,9 @@ def get_files_for_linting(allow_limited=True):
     uses a specific commit or branch (a so-called diff base) to compare
     against for changed files. (This requires ``allow_limited=True``.)
 
-    To speed up linting on Travis pull requests against master, we manually
-    set the diff base to origin/master. We don't do this on non-pull requests
-    since origin/master will be equivalent to the currently checked out code.
+    To speed up linting on Travis pull requests against main, we manually
+    set the diff base to origin/main. We don't do this on non-pull requests
+    since origin/main will be equivalent to the currently checked out code.
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
@@ -122,11 +122,11 @@ def get_files_for_linting(allow_limited=True):
               linted.
     """
     diff_base = None
-    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+    if (os.getenv('TRAVIS_BRANCH') == 'main' and
             os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
-        # In the case of a pull request into master, we want to
-        # diff against HEAD in master.
-        diff_base = 'origin/master'
+        # In the case of a pull request into main, we want to
+        # diff against HEAD in main.
+        diff_base = 'origin/main'
     elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
         remote = os.getenv('GCLOUD_REMOTE_FOR_LINT')

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
@@ -398,8 +398,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -426,11 +426,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -461,7 +461,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -515,15 +515,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -710,15 +710,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/kms/layer1.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
@@ -139,8 +139,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -169,8 +169,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -399,8 +399,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -424,8 +424,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -563,7 +563,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -594,8 +594,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -681,8 +681,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
@@ -319,8 +319,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -415,9 +415,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -450,8 +450,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -534,7 +534,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -653,8 +653,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2478,7 +2478,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2606,14 +2606,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2624,7 +2624,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2658,7 +2658,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2810,8 +2810,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
@@ -182,7 +182,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -238,7 +238,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(response.instancegroups[0].name, "Main instance group")
         self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
         self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
@@ -566,7 +566,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -598,7 +598,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.status.state, 'TERMINATED')
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
-        self.assertEqual(response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -836,7 +836,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -853,7 +853,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -871,11 +871,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -903,14 +903,14 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -932,7 +932,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1000,5 +1000,5 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster' },
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/oauth2client/docs/conf.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/oauth2client/docs/conf.py
@@ -17,7 +17,7 @@ extensions = [
 ]
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 # General information about the project.
 project = u'oauth2client'

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/rsa/doc/conf.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/rsa/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Python-RSA'

--- a/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
+++ b/frontend/yes/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.